### PR TITLE
Update Airtable votes per person with one button click

### DIFF
--- a/app/api/airtable-party-people/route.ts
+++ b/app/api/airtable-party-people/route.ts
@@ -44,14 +44,16 @@ type SingleSelectField = {
   type: "singleSelect";
   name: string;
   description?: string;
-  options: Array<{
-    id: string;
-    // More specific colors can be got from
-    // https://airtable.com/developers/web/api/field-model#select
-    // but for our uses, we don't care.
-    color?: string;
-    name: string;
-  }>;
+  options: {
+    choices: Array<{
+      id: string;
+      // More specific colors can be got from
+      // https://airtable.com/developers/web/api/field-model#select
+      // but for our uses, we don't care.
+      color?: string;
+      name: string;
+    }>;
+  };
 };
 
 type TableField = {
@@ -102,7 +104,7 @@ export async function GET(request: Request) {
     acc.push({
       id: field.id,
       name: field.name,
-      options: field.options,
+      options: field.options.choices,
     });
     return acc;
   }, [] as AirtablePerson[]);

--- a/app/api/airtable-party-people/route.ts
+++ b/app/api/airtable-party-people/route.ts
@@ -1,3 +1,4 @@
+import { AirtablePerson } from "@/app/types/airtable";
 import Airtable from "airtable";
 
 // A good enough type for our uses
@@ -38,9 +39,24 @@ type FieldType =
   | "lastModifiedBy"
   | "externalSyncSource";
 
+type SingleSelectField = {
+  id: string;
+  type: "singleSelect";
+  name: string;
+  description?: string;
+  options: Array<{
+    id: string;
+    // More specific colors can be got from
+    // https://airtable.com/developers/web/api/field-model#select
+    // but for our uses, we don't care.
+    color?: string;
+    name: string;
+  }>;
+};
+
 type TableField = {
   id: string;
-  type?: FieldType;
+  type?: Exclude<FieldType, "singleSelect">;
   name: string;
   description?: string;
 };
@@ -53,7 +69,7 @@ type TableSchema = {
   name: string;
   description?: string;
 
-  fields: Array<TableField>;
+  fields: Array<SingleSelectField | TableField>;
 };
 
 export async function GET(request: Request) {
@@ -80,13 +96,16 @@ export async function GET(request: Request) {
     throw new Error("Table was not found, meta request seems to be broken");
   }
 
-  const people = tableSchema.fields
+  const people = tableSchema.fields.reduce((acc, field) => {
     // Only party people columns use the singleSelect type
-    .filter((field) => field.type === "singleSelect")
-    .map((field) => ({
+    if (field.type !== "singleSelect") return acc;
+    acc.push({
       id: field.id,
       name: field.name,
-    }));
+      options: field.options,
+    });
+    return acc;
+  }, [] as AirtablePerson[]);
 
   return new Response(JSON.stringify(people), {
     headers: {

--- a/app/api/airtable-update-items/route.ts
+++ b/app/api/airtable-update-items/route.ts
@@ -1,0 +1,52 @@
+import Airtable from "airtable";
+import { AirtableUpdateRecordPayload } from "@/app/types/airtable";
+
+export async function PUT(request: Request) {
+  const airtable = new Airtable({
+    apiKey: process.env.AIRTABLE_API_KEY,
+  });
+  // The Airtable base where all data lives in
+  const baseId = "appZo5EslvhMHndic";
+  // The table ID which contains the wanted stuff
+  const tableId = "tbloo3DrzmMKRTrQX";
+
+  // We assume that incoming request contains the payload in the expected format here.
+  const updatePayload: AirtableUpdateRecordPayload[] = await request.json();
+
+  // Airtable allows updating at max 10 records in same request so we must split the payload
+  // to buckets of max 10.
+  const bucketedUpdatePayloads = updatePayload.reduce(
+    (acc, singlePayload, index) => {
+      const bucketId = Math.floor(index / 10);
+      acc[bucketId] ||= [];
+      acc[bucketId].push(singlePayload);
+      return acc;
+    },
+    [] as AirtableUpdateRecordPayload[][]
+  );
+
+  for (const bucket of bucketedUpdatePayloads) {
+    const airtableFormat = bucket.map((item) => ({
+      id: item.recordId,
+      fields: {
+        // When we want to clear a selection from a singleSelect item,
+        // we can set the item to `null`. However, the types provided by airtable
+        // package enforce all fields to be strings or it causes a type error.
+        //
+        // So we must tell TypeScript here that `null` is a string to appease
+        // the types provided inside Airtable. Yuck.
+        [item.field]: item.choiceId as string,
+      },
+    }));
+    const bucketResponse = await airtable
+      .base(baseId)
+      .table(tableId)
+      .update(airtableFormat);
+  }
+
+  return new Response(JSON.stringify({ message: "All good" }), {
+    headers: {
+      "content-type": "application/json",
+    },
+  });
+}

--- a/app/apiCalls.ts
+++ b/app/apiCalls.ts
@@ -1,4 +1,8 @@
-import { AirtablePerson, AirtableRecord } from "./types/airtable";
+import {
+  AirtablePerson,
+  AirtableRecord,
+  AirtableUpdateRecordPayload,
+} from "./types/airtable";
 
 export async function getPeopleFromAirtable(): Promise<AirtablePerson[]> {
   const res = await fetch("http://localhost:3000/api/airtable-party-people");
@@ -28,4 +32,18 @@ export async function getRecordsFromAirtable(): Promise<AirtableRecord[]> {
   }
 
   return res.json();
+}
+
+export async function updateRecordVotes(
+  updates: AirtableUpdateRecordPayload[]
+): Promise<void> {
+  const res = await fetch("http://localhost:3000/api/airtable-update-items", {
+    method: "PUT",
+    body: JSON.stringify(updates),
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error("Failed to update votes");
+  }
 }

--- a/app/apiCalls.ts
+++ b/app/apiCalls.ts
@@ -1,0 +1,15 @@
+import { AirtablePerson } from "./types/airtable";
+
+export async function getPeopleFromAirtable(): Promise<AirtablePerson[]> {
+  const res = await fetch("http://localhost:3000/api/airtable-party-people");
+  // The return value is *not* serialized
+  // You can return Date, Map, Set, etc.
+
+  // Recommendation: handle errors
+  if (!res.ok) {
+    // This will activate the closest `error.js` Error Boundary
+    throw new Error("Failed to fetch data");
+  }
+
+  return res.json();
+}

--- a/app/apiCalls.ts
+++ b/app/apiCalls.ts
@@ -1,7 +1,23 @@
-import { AirtablePerson } from "./types/airtable";
+import { AirtablePerson, AirtableRecord } from "./types/airtable";
 
 export async function getPeopleFromAirtable(): Promise<AirtablePerson[]> {
   const res = await fetch("http://localhost:3000/api/airtable-party-people");
+  // The return value is *not* serialized
+  // You can return Date, Map, Set, etc.
+
+  // Recommendation: handle errors
+  if (!res.ok) {
+    // This will activate the closest `error.js` Error Boundary
+    throw new Error("Failed to fetch data");
+  }
+
+  return res.json();
+}
+
+export async function getRecordsFromAirtable(): Promise<AirtableRecord[]> {
+  const res = await fetch("http://localhost:3000/api/airtable-party-person", {
+    cache: "no-store",
+  });
   // The return value is *not* serialized
   // You can return Date, Map, Set, etc.
 

--- a/app/layout.module.css
+++ b/app/layout.module.css
@@ -1,9 +1,0 @@
-.appWrapper {
-  height: 100vh;
-}
-
-.heading {
-  font-size: 3rem;
-  padding: 3rem 1.5rem;
-  text-align: center;
-}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import { Lobster } from "next/font/google";
 import "./globals.css";
-import styles from "./layout.module.css";
 
 export const metadata = {
   title: "Eurovision Airtable",
@@ -18,8 +17,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <div className={styles.appWrapper}>
-          <h1 className={`${lobster.className} ${styles.heading}`}>
+        <div className="h-screen">
+          <h1
+            className={`${lobster.className} px-6 py-12 text-center text-5xl`}
+          >
             Viisukatsomo
           </h1>
           {children}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { Lobster } from "next/font/google";
 import "./globals.css";
 
@@ -21,7 +22,7 @@ export default function RootLayout({
           <h1
             className={`${lobster.className} px-6 py-12 text-center text-5xl`}
           >
-            Viisukatsomo
+            <Link href="/">Viisukatsomo</Link>
           </h1>
           {children}
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import Link from "next/link";
 import styles from "./page.module.css";
 import { getPeopleFromAirtable } from "./apiCalls";

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,9 +4,7 @@ import styles from "./page.module.css";
 import { AirtablePerson } from "./types/airtable";
 
 async function getPeopleFromAirtable(): Promise<AirtablePerson[]> {
-  const res = await fetch("http://localhost:3000/api/airtable-party-people", {
-    cache: "no-store",
-  });
+  const res = await fetch("http://localhost:3000/api/airtable-party-people");
   // The return value is *not* serialized
   // You can return Date, Map, Set, etc.
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,21 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import styles from "./page.module.css";
-import { AirtablePerson } from "./types/airtable";
-
-async function getPeopleFromAirtable(): Promise<AirtablePerson[]> {
-  const res = await fetch("http://localhost:3000/api/airtable-party-people");
-  // The return value is *not* serialized
-  // You can return Date, Map, Set, etc.
-
-  // Recommendation: handle errors
-  if (!res.ok) {
-    // This will activate the closest `error.js` Error Boundary
-    throw new Error("Failed to fetch data");
-  }
-
-  return res.json();
-}
+import { getPeopleFromAirtable } from "./apiCalls";
 
 export default async function Home() {
   const people = await getPeopleFromAirtable();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,9 @@
 import Image from "next/image";
 import Link from "next/link";
 import styles from "./page.module.css";
+import { AirtablePerson } from "./types/airtable";
 
-type Person = {
-  name: string;
-  id: string;
-};
-type People = Array<Person>;
-
-async function getPeopleFromAirtable(): Promise<People> {
+async function getPeopleFromAirtable(): Promise<AirtablePerson[]> {
   const res = await fetch("http://localhost:3000/api/airtable-party-people", {
     cache: "no-store",
   });

--- a/app/party-people/[partyPerson]/Ranking.stories.ts
+++ b/app/party-people/[partyPerson]/Ranking.stories.ts
@@ -4,7 +4,35 @@ import { Ranking } from "./Ranking";
 // More on how to set up stories at: https://storybook.js.org/docs/7.0/react/writing-stories/introduction
 const meta: Meta<typeof Ranking> = {
   component: Ranking,
-  args: { records: [] },
+  args: {
+    records: [],
+    person: {
+      id: "someId123",
+      name: "Ranker",
+      options: [
+        {
+          id: "selx2unbJlKpTWOVe",
+          name: "🤩",
+        },
+        {
+          id: "selnOCupL0qaO7Dmu",
+          name: "😁",
+        },
+        {
+          id: "selLH1BrM0J9Z7gXL",
+          name: "🙂",
+        },
+        {
+          id: "selrJ1M3MkOUuip8g",
+          name: "😐",
+        },
+        {
+          id: "sel5epwTJ63GGAv8d",
+          name: "😖",
+        },
+      ],
+    },
+  },
 };
 
 export default meta;

--- a/app/party-people/[partyPerson]/Ranking.stories.ts
+++ b/app/party-people/[partyPerson]/Ranking.stories.ts
@@ -4,7 +4,7 @@ import { Ranking } from "./Ranking";
 // More on how to set up stories at: https://storybook.js.org/docs/7.0/react/writing-stories/introduction
 const meta: Meta<typeof Ranking> = {
   component: Ranking,
-  args: { items: [] },
+  args: { records: [] },
 };
 
 export default meta;
@@ -12,7 +12,7 @@ type Story = StoryObj<typeof Ranking>;
 
 export const Unranked: Story = {
   args: {
-    items: [
+    records: [
       {
         fields: {
           Country: "United Kingdom",

--- a/app/party-people/[partyPerson]/Ranking.tsx
+++ b/app/party-people/[partyPerson]/Ranking.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type AirtableItem } from "@/app/types/airtable";
+import { type AirtableRecord } from "@/app/types/airtable";
 
 import React from "react";
 import {
@@ -12,11 +12,11 @@ import {
   DropResult,
 } from "react-beautiful-dnd";
 interface Props {
-  items: Array<AirtableItem>;
+  records: Array<AirtableRecord>;
 }
 
 type State = {
-  [key: string]: AirtableItem[];
+  [key: string]: AirtableRecord[];
 };
 
 // a little function to help us with reordering the result
@@ -28,16 +28,16 @@ const reorder = (list: any[], startIndex: number, endIndex: number): any[] => {
   return result;
 };
 
-export const Ranking = ({ items: originalItems }: Props) => {
+export const Ranking = ({ records: originalRecords }: Props) => {
   const [isReordering, setIsReordering] = React.useState(false);
 
-  const [items, setItems] = React.useState<State>(
-    originalItems.reduce((acc, item, index) => {
+  const [records, setRecords] = React.useState<State>(
+    originalRecords.reduce((acc, record, index) => {
       const groupName = `idx_${Math.floor(index / 7)}`;
       if (!acc[groupName]) {
         acc[groupName] = [];
       }
-      acc[groupName].push(item);
+      acc[groupName].push(record);
       return acc;
     }, {} as State)
   );
@@ -49,22 +49,22 @@ export const Ranking = ({ items: originalItems }: Props) => {
 
     const source = result.source;
     const destination = result.destination;
-    const current: AirtableItem[] = [...items[source.droppableId]];
-    const next: AirtableItem[] = [...items[destination.droppableId]];
-    const target: AirtableItem = current[source.index];
+    const current: AirtableRecord[] = [...records[source.droppableId]];
+    const next: AirtableRecord[] = [...records[destination.droppableId]];
+    const target: AirtableRecord = current[source.index];
 
     // moving to same list
     if (source.droppableId === destination.droppableId) {
-      const reordered: AirtableItem[] = reorder(
+      const reordered: AirtableRecord[] = reorder(
         current,
         source.index,
         destination.index
       );
       const result: State = {
-        ...items,
+        ...records,
         [source.droppableId]: reordered,
       };
-      setItems(result);
+      setRecords(result);
       return;
     }
 
@@ -76,11 +76,11 @@ export const Ranking = ({ items: originalItems }: Props) => {
     next.splice(destination.index, 0, target);
 
     const resultTwo: State = {
-      ...items,
+      ...records,
       [source.droppableId]: current,
       [destination.droppableId]: next,
     };
-    setItems(resultTwo);
+    setRecords(resultTwo);
     return;
   };
   return (
@@ -97,7 +97,7 @@ export const Ranking = ({ items: originalItems }: Props) => {
         <div
           className={`ml-4 mr-4 flex h-full w-full flex-shrink-0 overflow-auto`}
         >
-          {Object.entries(items).map(([columnId, list]) => (
+          {Object.entries(records).map(([columnId, list]) => (
             <Droppable droppableId={columnId} key={columnId}>
               {(provided: DroppableProvided) => (
                 <div
@@ -108,10 +108,10 @@ export const Ranking = ({ items: originalItems }: Props) => {
                   } flex flex-shrink-0 flex-col`}
                 >
                   <div className="w-32 pb-2">{columnId}</div>
-                  {list.map((item, index) => (
+                  {list.map((record, index) => (
                     <Draggable
-                      key={item.id}
-                      draggableId={item.id}
+                      key={record.id}
+                      draggableId={record.id}
                       index={index}
                     >
                       {(provided: DraggableProvided, draggableSnapshot) => (
@@ -120,8 +120,8 @@ export const Ranking = ({ items: originalItems }: Props) => {
                           ref={provided.innerRef}
                           {...provided.dragHandleProps}
                         >
-                          <SingleItem
-                            item={item}
+                          <SingleRecord
+                            record={record}
                             isReordering={isReordering}
                             isDragging={draggableSnapshot.isDragging}
                           />
@@ -139,12 +139,12 @@ export const Ranking = ({ items: originalItems }: Props) => {
   );
 };
 
-const SingleItem = ({
-  item,
+const SingleRecord = ({
+  record,
   isReordering,
   isDragging,
 }: {
-  item: AirtableItem;
+  record: AirtableRecord;
   isReordering: boolean;
   isDragging: boolean;
 }) => (
@@ -157,11 +157,11 @@ const SingleItem = ({
       }`}
     >
       <div className="font-medium text-gray-200">
-        {item.fields.Flag} {!isReordering && item.fields.Country}
+        {record.fields.Flag} {!isReordering && record.fields.Country}
       </div>
       {!isReordering && (
         <div className="mt-2 text-sm text-green-300">
-          {item.fields.Artist} — {item.fields.Song}
+          {record.fields.Artist} — {record.fields.Song}
         </div>
       )}
     </div>

--- a/app/party-people/[partyPerson]/Ranking.tsx
+++ b/app/party-people/[partyPerson]/Ranking.tsx
@@ -42,7 +42,7 @@ export const Ranking = ({ records: originalRecords, person }: Props) => {
       };
     },
     {
-      Uncategorized: originalRecords.filter(
+      NOT_RANKED: originalRecords.filter(
         // @ts-ignore -- This works but I don't know TS well enough to permit this
         (record) => record.fields[person.name] === undefined
       ),
@@ -117,7 +117,13 @@ export const Ranking = ({ records: originalRecords, person }: Props) => {
                     isReordering ? "mr-4 w-8" : "w-82 mr-6"
                   } flex flex-shrink-0 flex-col`}
                 >
-                  <div className="w-32 pb-2">{columnId}</div>
+                  <div className="w-32 pb-2">
+                    {columnId === "NOT_RANKED"
+                      ? isReordering
+                        ? "???"
+                        : "Not ranked"
+                      : columnId}
+                  </div>
                   {list.map((record, index) => (
                     <Draggable
                       key={record.id}

--- a/app/party-people/[partyPerson]/Ranking.tsx
+++ b/app/party-people/[partyPerson]/Ranking.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type AirtableRecord } from "@/app/types/airtable";
+import { type AirtablePerson, type AirtableRecord } from "@/app/types/airtable";
 
 import React from "react";
 import {
@@ -13,6 +13,7 @@ import {
 } from "react-beautiful-dnd";
 interface Props {
   records: Array<AirtableRecord>;
+  person: AirtablePerson;
 }
 
 type State = {
@@ -28,19 +29,28 @@ const reorder = (list: any[], startIndex: number, endIndex: number): any[] => {
   return result;
 };
 
-export const Ranking = ({ records: originalRecords }: Props) => {
+export const Ranking = ({ records: originalRecords, person }: Props) => {
+  const initialGroups = person.options.reduce(
+    (acc, option) => {
+      const recordsInThisGroup = originalRecords.filter(
+        // @ts-ignore -- This works but I don't know TS well enough to permit this
+        (record) => record.fields[person.name] === option.name
+      );
+      return {
+        ...acc,
+        [option.name]: recordsInThisGroup,
+      };
+    },
+    {
+      Uncategorized: originalRecords.filter(
+        // @ts-ignore -- This works but I don't know TS well enough to permit this
+        (record) => record.fields[person.name] === undefined
+      ),
+    }
+  );
   const [isReordering, setIsReordering] = React.useState(false);
 
-  const [records, setRecords] = React.useState<State>(
-    originalRecords.reduce((acc, record, index) => {
-      const groupName = `idx_${Math.floor(index / 7)}`;
-      if (!acc[groupName]) {
-        acc[groupName] = [];
-      }
-      acc[groupName].push(record);
-      return acc;
-    }, {} as State)
-  );
+  const [records, setRecords] = React.useState<State>(initialGroups);
 
   const dragHandler = (result: DropResult) => {
     if (!result.destination) {

--- a/app/party-people/[partyPerson]/Ranking.tsx
+++ b/app/party-people/[partyPerson]/Ranking.tsx
@@ -67,6 +67,10 @@ export const Ranking = ({ records: originalRecords, person }: Props) => {
 
   const [records, setRecords] = React.useState<State>(initialGroups);
 
+  useUnsavedChangesWarning(
+    requestState.type !== "FRESH" && requestState.type !== "SUCCESS"
+  );
+
   const dragHandler = (result: DropResult) => {
     if (requestState.type === "SENDING") {
       // Abort drag handling when request is in progress
@@ -267,3 +271,20 @@ const SingleRecord = ({
     </div>
   </>
 );
+
+function useUnsavedChangesWarning(hasUnsavedChanges: boolean) {
+  React.useEffect(() => {
+    if (!hasUnsavedChanges) return;
+    const beforeUnloadHandler = (event: BeforeUnloadEvent) => {
+      const warningMessage =
+        "You have not saved all your votes, are you sure you want to leave?";
+
+      event.returnValue = warningMessage;
+      return warningMessage;
+    };
+    window.addEventListener("beforeunload", beforeUnloadHandler);
+    return () => {
+      window.removeEventListener("beforeunload", beforeUnloadHandler);
+    };
+  }, [hasUnsavedChanges]);
+}

--- a/app/party-people/[partyPerson]/page.tsx
+++ b/app/party-people/[partyPerson]/page.tsx
@@ -1,4 +1,4 @@
-import { type AirtableItem } from "@/app/types/airtable";
+import { type AirtableRecord } from "@/app/types/airtable";
 import { Ranking } from "./Ranking";
 
 type Params = { partyPerson: string };
@@ -6,9 +6,7 @@ type Props = {
   params: Params;
 };
 
-type AirtableData = Array<AirtableItem>;
-
-async function getDataFromAirtable(): Promise<AirtableData> {
+async function getRecordsFromAirtable(): Promise<AirtableRecord[]> {
   const res = await fetch("http://localhost:3000/api/airtable-party-person", {
     cache: "no-store",
   });
@@ -25,14 +23,14 @@ async function getDataFromAirtable(): Promise<AirtableData> {
 }
 
 export default async function PartyPersonPage({ params }: Props) {
-  const data = await getDataFromAirtable();
+  const records = await getRecordsFromAirtable();
 
   return (
     <>
       <div className="text-3xl font-bold">
         PartyPerson: {params.partyPerson}
       </div>
-      <Ranking items={data} />
+      <Ranking records={records} />
     </>
   );
 }

--- a/app/party-people/[partyPerson]/page.tsx
+++ b/app/party-people/[partyPerson]/page.tsx
@@ -1,5 +1,6 @@
 import { type AirtableRecord } from "@/app/types/airtable";
 import { Ranking } from "./Ranking";
+import { getPeopleFromAirtable } from "@/app/apiCalls";
 
 type Params = { partyPerson: string };
 type Props = {
@@ -24,11 +25,23 @@ async function getRecordsFromAirtable(): Promise<AirtableRecord[]> {
 
 export default async function PartyPersonPage({ params }: Props) {
   const records = await getRecordsFromAirtable();
+  const people = await getPeopleFromAirtable();
+  const person = people.find((person) => person.id === params.partyPerson);
+
+  if (!person) {
+    return (
+      <>
+        <div className="text-3xl font-bold">
+          Error: Unknown party person {params.partyPerson}
+        </div>
+      </>
+    );
+  }
 
   return (
     <>
-      <div className="text-3xl font-bold">
-        PartyPerson: {params.partyPerson}
+      <div className="mb-8 flex flex-col items-center">
+        <div className="text-3xl font-bold">{person.name}'s picks</div>
       </div>
       <Ranking records={records} />
     </>

--- a/app/party-people/[partyPerson]/page.tsx
+++ b/app/party-people/[partyPerson]/page.tsx
@@ -43,7 +43,7 @@ export default async function PartyPersonPage({ params }: Props) {
       <div className="mb-8 flex flex-col items-center">
         <div className="text-3xl font-bold">{person.name}'s picks</div>
       </div>
-      <Ranking records={records} />
+      <Ranking records={records} person={person} />
     </>
   );
 }

--- a/app/party-people/[partyPerson]/page.tsx
+++ b/app/party-people/[partyPerson]/page.tsx
@@ -1,27 +1,10 @@
-import { type AirtableRecord } from "@/app/types/airtable";
 import { Ranking } from "./Ranking";
-import { getPeopleFromAirtable } from "@/app/apiCalls";
+import { getPeopleFromAirtable, getRecordsFromAirtable } from "@/app/apiCalls";
 
 type Params = { partyPerson: string };
 type Props = {
   params: Params;
 };
-
-async function getRecordsFromAirtable(): Promise<AirtableRecord[]> {
-  const res = await fetch("http://localhost:3000/api/airtable-party-person", {
-    cache: "no-store",
-  });
-  // The return value is *not* serialized
-  // You can return Date, Map, Set, etc.
-
-  // Recommendation: handle errors
-  if (!res.ok) {
-    // This will activate the closest `error.js` Error Boundary
-    throw new Error("Failed to fetch data");
-  }
-
-  return res.json();
-}
 
 export default async function PartyPersonPage({ params }: Props) {
   const records = await getRecordsFromAirtable();

--- a/app/types/airtable.ts
+++ b/app/types/airtable.ts
@@ -20,3 +20,9 @@ export type AirtablePerson = {
   name: string;
   options: Array<{ id: string; name: string }>;
 };
+
+export type AirtableUpdateRecordPayload = {
+  recordId: string;
+  field: string;
+  choiceId: string | null;
+};

--- a/app/types/airtable.ts
+++ b/app/types/airtable.ts
@@ -14,3 +14,9 @@ export type AirtableItem = {
     YouTube: string;
   };
 };
+
+export type AirtablePerson = {
+  id: string;
+  name: string;
+  options: Array<{ id: string; name: string }>;
+};

--- a/app/types/airtable.ts
+++ b/app/types/airtable.ts
@@ -1,4 +1,4 @@
-export type AirtableItem = {
+export type AirtableRecord = {
   /** The ID representing this record in Airtable */
   id: string;
   fields: {


### PR DESCRIPTION
This PR adds API support where ranking of entries can be updated in Airtable with a single click.

The Airtable API [docs](https://airtable.com/appZo5EslvhMHndic/api/docs#javascript/table:esc%202023%20preview:update) `update` method will only update the fields you include. This allows all party people to vote at the same time and not risk overriding each others votes.